### PR TITLE
Dash to dock settings

### DIFF
--- a/schemas/99_manjaro-settings.gschema.override
+++ b/schemas/99_manjaro-settings.gschema.override
@@ -2,6 +2,9 @@
 picture-uri='file:///usr/share/backgrounds/manjarowall17_07.jpg'
 show-desktop-icons=false
 
+[org.gnome.settings-daemon.plugins.color}
+night-light-enabled=true
+
 [org.gnome.desktop.interface]
 cursor-theme='Breeze'
 document-font-name='Sans 11'

--- a/scripts/dtd-settings
+++ b/scripts/dtd-settings
@@ -6,4 +6,4 @@ gsettings set org.gnome.shell.extensions.dash-to-dock apply-custom-theme=true
 gsettings set org.gnome.shell.extensions.dash-to-dock custom-theme-shrink=true
 gsettings set org.gnome.shell.extensions.dash-to-dock background-opacity=0.90000000000000002220
 gsettings set org.gnome.shell.extensions.dash-to-dock custom-theme-running-dots=false
-rm ~/.config/autostart/dash-to-dock-settings.desktop
+rm ~/.config/autostart/dtd-settings.desktop

--- a/scripts/dtd-settings
+++ b/scripts/dtd-settings
@@ -1,0 +1,9 @@
+#!/bin/sh
+gsettings set org.gnome.shell.extensions.dash-to-dock dock-fixed true
+gsettings set org.gnome.shell.extensions.dash-to-dock extend-height true
+gsettings set org.gnome.shell.extensions.dash-to-dock dash-max-icon-size=32
+gsettings set org.gnome.shell.extensions.dash-to-dock apply-custom-theme=true
+gsettings set org.gnome.shell.extensions.dash-to-dock custom-theme-shrink=true
+gsettings set org.gnome.shell.extensions.dash-to-dock background-opacity=0.90000000000000002220
+gsettings set org.gnome.shell.extensions.dash-to-dock custom-theme-running-dots=false
+rm ~/.config/autostart/dash-to-dock-settings.desktop

--- a/skel/.config/autostart/dtd-settings.desktop
+++ b/skel/.config/autostart/dtd-settings.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Exec=dtd-settings
+Name=dtd-settings
+Comment=Set theming for Dash to dock extension
+Type=Application
+Icon=nautilus
+StartupNotify=false
+NotShowIn=KDE;
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
Set dash to dock settings with shell script as a temporary workaround. Addresses issue #3 . Also, enable nightlight by default.